### PR TITLE
feat: implement smooth scroll for all on-page links

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     // Exemplo de script: Smooth scroll para links internos
-    const navLinks = document.querySelectorAll('.nav a[href^="#"]');
+    const navLinks = document.querySelectorAll('a[href^="#"]');
 
     navLinks.forEach(link => {
         link.addEventListener('click', function(e) {


### PR DESCRIPTION
Modified script.js to generalize the smooth scroll functionality. The query selector was changed from '.nav a[href^="#"]' to 'a[href^="#"]' to ensure that all internal links, including the 'Fale Conosco' button, trigger a smooth scroll to the target section.