### PR TITLE
feat: Standardize charger image sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,24 +70,24 @@
                     <div class="carregador-info">
                         <h3>AC (7.3kW, 11kW, 22kW) - CARGA LENTA</h3>
                         <p>Ideais para carros híbridos em recarga diária/noite.</p>
-                        <img src="./src/CARREGADOR_AC.webp" alt="Carregador AC VIA VOLT">
+                        <img src="./src/CARREGADOR_AC.webp" alt="Carregador AC VIA VOLT" class="carregador-imagem">
                     </div>
                     <div class="carregador-info">
                         <h3>DC (30kW, 40kW) - CARGA RÁPIDA</h3>
                         <p>Ideais para carros elétricos e híbridos plug-in, com carga rápida em áreas comuns.</p>
-                        <img src="./src/carregador-dc.webp" alt="Carregador DC VIA VOLT">
+                        <img src="./src/carregador-dc.webp" alt="Carregador DC VIA VOLT" class="carregador-imagem">
                     </div>
 
                     <div class="carregador-info">
                         <h3>AC (60k a 120k) - CARGA RÁPIDA</h3>
                         <p>Perfeitos para carros elétricos e híbridos plug-in, nossas soluções oferecem carga rápida em áreas comuns.</p>
-                        <img src="./src/CARREGADOR 60 A 120.webp" alt="Carregador AC VIA VOLT">
+                        <img src="./src/CARREGADOR 60 A 120.webp" alt="Carregador AC VIA VOLT" class="carregador-imagem">
                     </div>
 
                     <div class="carregador-info">
                         <h3>DC (160kW a 240kW) - CARGA RÁPIDA</h3>
                         <p>Para veículos elétricos e híbridos plug-in, com carga rápida em áreas comuns.</p>
-                        <img src="./src/CARREGADOR 160 A 240.webp" alt="Carregador DC VIA VOLT">
+                        <img src="./src/CARREGADOR 160 A 240.webp" alt="Carregador DC VIA VOLT" class="carregador-imagem">
                     </div>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -135,6 +135,12 @@ section h2 { font-size: 2.5rem; margin-bottom: 50px; }
     border-radius: 10px; box-shadow: 0 4px 10px var(--shadow-color);
 }
 
+.carregador-imagem {
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+}
+
 /* Benefícios */
 .beneficios { background:#fff; padding:80px 0; }
 .beneficios-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:20px; }


### PR DESCRIPTION
This commit applies a uniform size to the four charger images in the "Carregadores" section.

- A new CSS class, `carregador-imagem`, was created to set a fixed height of 250px and an `object-fit` of `cover`.
- This class was applied to the four charger images in `index.html` to ensure they are all displayed at the same size, improving the visual consistency of the layout.